### PR TITLE
Create public route table

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,3 +30,14 @@ resource "aws_internet_gateway" "vpc-1-igw" {
     Name = "vpc-1-igw"
   }
 }
+
+resource "aws_route_table" "vpc-1-public-rt" {
+  vpc_id = "${aws_vpc.vpc-1.id}"
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.vpc-1-igw.id}"
+  }
+  tags {
+    Name = "vpc-1-public-rt"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -41,3 +41,8 @@ resource "aws_route_table" "vpc-1-public-rt" {
     Name = "vpc-1-public-rt"
   }
 }
+
+resource "aws_route_table_association" "vpc-1-rta-1" {
+  subnet_id      = "${aws_subnet.vpc-1-public-subnet.id}"
+  route_table_id = "${aws_route_table.vpc-1-public-rt.id}"
+}

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.11.1",
-    "serial": 6,
+    "serial": 7,
     "lineage": "9bc7f940-e849-43f4-a648-6c4237774fb9",
     "modules": [
         {
@@ -22,6 +22,55 @@
                             "tags.%": "1",
                             "tags.Name": "vpc-1-igw",
                             "vpc_id": "vpc-ca39caad"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_route_table.vpc-1-public-rt": {
+                    "type": "aws_route_table",
+                    "depends_on": [
+                        "aws_internet_gateway.vpc-1-igw",
+                        "aws_vpc.vpc-1"
+                    ],
+                    "primary": {
+                        "id": "rtb-2e295c49",
+                        "attributes": {
+                            "id": "rtb-2e295c49",
+                            "propagating_vgws.#": "0",
+                            "route.#": "1",
+                            "route.455298170.cidr_block": "0.0.0.0/0",
+                            "route.455298170.egress_only_gateway_id": "",
+                            "route.455298170.gateway_id": "igw-3e3d865a",
+                            "route.455298170.instance_id": "",
+                            "route.455298170.ipv6_cidr_block": "",
+                            "route.455298170.nat_gateway_id": "",
+                            "route.455298170.network_interface_id": "",
+                            "route.455298170.vpc_peering_connection_id": "",
+                            "tags.%": "1",
+                            "tags.Name": "vpc-1-public-rt",
+                            "vpc_id": "vpc-ca39caad"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_route_table_association.vpc-1-rta-1": {
+                    "type": "aws_route_table_association",
+                    "depends_on": [
+                        "aws_route_table.vpc-1-public-rt",
+                        "aws_subnet.vpc-1-public-subnet"
+                    ],
+                    "primary": {
+                        "id": "rtbassoc-f02d9196",
+                        "attributes": {
+                            "id": "rtbassoc-f02d9196",
+                            "route_table_id": "rtb-2e295c49",
+                            "subnet_id": "subnet-3d69fe74"
                         },
                         "meta": {},
                         "tainted": false


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17349045/33507334-8846580e-d737-11e7-96df-5dafd0480899.png)
※ ルートテーブルID`rtb-f992f89e`のルートテーブルはvpc-1作成時にデフォルトで作成されていたルートテーブル。ここでは区別するためにダッシュボード上より名前`default-rt`を追加しました。
