### PR TITLE
create ec2 instance for web-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
+*.pem
 .terraform
 terraform.tfstate.info
 terraform.tfstate.backup

--- a/ec2.tf
+++ b/ec2.tf
@@ -1,0 +1,9 @@
+resource "aws_instance" "web-server" {
+  ami           = "ami-da9e2cbc"
+  instance_type = "t2.micro"
+  associate_public_ip_address = true
+
+  tags {
+    Name = "web-server"
+  }
+}

--- a/ec2.tf
+++ b/ec2.tf
@@ -1,11 +1,12 @@
 resource "aws_instance" "web-server" {
-  ami           = "ami-da9e2cbc"
-  instance_type = "t2.micro"
+  ami                    = "ami-da9e2cbc"
+  instance_type          = "t2.micro"
+  key_name               = "${var.key_name}"
+  subnet_id              = "${aws_subnet.vpc-1-public-subnet.id}"
+  vpc_security_group_ids = ["${aws_security_group.web-sg.id}"]
 
-  network_interface {
-    network_interface_id = "${aws_network_interface.web-server-ni.id}"
-    device_index = 0
-  }
+  associate_public_ip_address = true
+  private_ip                  = "10.0.1.10"
 
   tags {
     Name = "web-server"

--- a/ec2.tf
+++ b/ec2.tf
@@ -1,7 +1,11 @@
 resource "aws_instance" "web-server" {
   ami           = "ami-da9e2cbc"
   instance_type = "t2.micro"
-  associate_public_ip_address = true
+
+  network_interface {
+    network_interface_id = "${aws_network_interface.web-server-ni.id}"
+    device_index = 0
+  }
 
   tags {
     Name = "web-server"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 variable "access_key" {}
 variable "secret_key" {}
 variable "region" {}
+variable "key_name" {}
 
 provider "aws" {
   access_key = "${var.access_key}"

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.11.1",
-    "serial": 10,
+    "serial": 11,
     "lineage": "9bc7f940-e849-43f4-a648-6c4237774fb9",
     "modules": [
         {
@@ -12,46 +12,51 @@
             "resources": {
                 "aws_instance.web-server": {
                     "type": "aws_instance",
-                    "depends_on": [],
+                    "depends_on": [
+                        "aws_network_interface.web-server-ni"
+                    ],
                     "primary": {
-                        "id": "i-05dc749e699baec56",
+                        "id": "i-00b6359bc1e3ba5dd",
                         "attributes": {
                             "ami": "ami-da9e2cbc",
-                            "associate_public_ip_address": "true",
+                            "associate_public_ip_address": "false",
                             "availability_zone": "ap-northeast-1a",
                             "disable_api_termination": "false",
                             "ebs_block_device.#": "0",
                             "ebs_optimized": "false",
                             "ephemeral_block_device.#": "0",
                             "iam_instance_profile": "",
-                            "id": "i-05dc749e699baec56",
+                            "id": "i-00b6359bc1e3ba5dd",
                             "instance_state": "running",
                             "instance_type": "t2.micro",
                             "ipv6_addresses.#": "0",
                             "key_name": "",
                             "monitoring": "false",
-                            "network_interface.#": "0",
-                            "network_interface_id": "eni-d666dfea",
+                            "network_interface.#": "1",
+                            "network_interface.3304266946.delete_on_termination": "false",
+                            "network_interface.3304266946.device_index": "0",
+                            "network_interface.3304266946.network_interface_id": "eni-a453ea98",
+                            "network_interface_id": "eni-a453ea98",
                             "placement_group": "",
-                            "primary_network_interface_id": "eni-d666dfea",
-                            "private_dns": "ip-172-31-25-127.ap-northeast-1.compute.internal",
-                            "private_ip": "172.31.25.127",
-                            "public_dns": "ec2-54-178-184-44.ap-northeast-1.compute.amazonaws.com",
-                            "public_ip": "54.178.184.44",
+                            "primary_network_interface_id": "eni-a453ea98",
+                            "private_dns": "ip-10-0-1-10.ap-northeast-1.compute.internal",
+                            "private_ip": "10.0.1.10",
+                            "public_dns": "",
+                            "public_ip": "",
                             "root_block_device.#": "1",
                             "root_block_device.0.delete_on_termination": "true",
                             "root_block_device.0.iops": "100",
                             "root_block_device.0.volume_size": "8",
                             "root_block_device.0.volume_type": "gp2",
-                            "security_groups.#": "1",
-                            "security_groups.3814588639": "default",
+                            "security_groups.#": "0",
                             "source_dest_check": "true",
-                            "subnet_id": "subnet-d2188d9b",
+                            "subnet_id": "subnet-3d69fe74",
                             "tags.%": "1",
                             "tags.Name": "web-server",
                             "tenancy": "default",
                             "volume_tags.%": "0",
-                            "vpc_security_group_ids.#": "0"
+                            "vpc_security_group_ids.#": "1",
+                            "vpc_security_group_ids.1523452012": "sg-4fde1e36"
                         },
                         "meta": {
                             "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
@@ -78,6 +83,33 @@
                             "tags.%": "1",
                             "tags.Name": "vpc-1-igw",
                             "vpc_id": "vpc-ca39caad"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_network_interface.web-server-ni": {
+                    "type": "aws_network_interface",
+                    "depends_on": [
+                        "aws_subnet.vpc-1-public-subnet"
+                    ],
+                    "primary": {
+                        "id": "eni-a453ea98",
+                        "attributes": {
+                            "attachment.#": "0",
+                            "description": "",
+                            "id": "eni-a453ea98",
+                            "private_dns_name": "",
+                            "private_ip": "10.0.1.10",
+                            "private_ips.#": "1",
+                            "private_ips.625443963": "10.0.1.10",
+                            "security_groups.#": "1",
+                            "security_groups.1523452012": "sg-4fde1e36",
+                            "source_dest_check": "true",
+                            "subnet_id": "subnet-3d69fe74",
+                            "tags.%": "0"
                         },
                         "meta": {},
                         "tainted": false

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.11.1",
-    "serial": 11,
+    "serial": 14,
     "lineage": "9bc7f940-e849-43f4-a648-6c4237774fb9",
     "modules": [
         {
@@ -13,36 +13,34 @@
                 "aws_instance.web-server": {
                     "type": "aws_instance",
                     "depends_on": [
-                        "aws_network_interface.web-server-ni"
+                        "aws_security_group.web-sg",
+                        "aws_subnet.vpc-1-public-subnet"
                     ],
                     "primary": {
-                        "id": "i-00b6359bc1e3ba5dd",
+                        "id": "i-006562826efab761a",
                         "attributes": {
                             "ami": "ami-da9e2cbc",
-                            "associate_public_ip_address": "false",
+                            "associate_public_ip_address": "true",
                             "availability_zone": "ap-northeast-1a",
                             "disable_api_termination": "false",
                             "ebs_block_device.#": "0",
                             "ebs_optimized": "false",
                             "ephemeral_block_device.#": "0",
                             "iam_instance_profile": "",
-                            "id": "i-00b6359bc1e3ba5dd",
+                            "id": "i-006562826efab761a",
                             "instance_state": "running",
                             "instance_type": "t2.micro",
                             "ipv6_addresses.#": "0",
-                            "key_name": "",
+                            "key_name": "my-key",
                             "monitoring": "false",
-                            "network_interface.#": "1",
-                            "network_interface.3304266946.delete_on_termination": "false",
-                            "network_interface.3304266946.device_index": "0",
-                            "network_interface.3304266946.network_interface_id": "eni-a453ea98",
-                            "network_interface_id": "eni-a453ea98",
+                            "network_interface.#": "0",
+                            "network_interface_id": "eni-ca2e97f6",
                             "placement_group": "",
-                            "primary_network_interface_id": "eni-a453ea98",
+                            "primary_network_interface_id": "eni-ca2e97f6",
                             "private_dns": "ip-10-0-1-10.ap-northeast-1.compute.internal",
                             "private_ip": "10.0.1.10",
                             "public_dns": "",
-                            "public_ip": "",
+                            "public_ip": "13.115.38.146",
                             "root_block_device.#": "1",
                             "root_block_device.0.delete_on_termination": "true",
                             "root_block_device.0.iops": "100",
@@ -56,7 +54,7 @@
                             "tenancy": "default",
                             "volume_tags.%": "0",
                             "vpc_security_group_ids.#": "1",
-                            "vpc_security_group_ids.1523452012": "sg-4fde1e36"
+                            "vpc_security_group_ids.2931906610": "sg-be9152c7"
                         },
                         "meta": {
                             "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
@@ -83,33 +81,6 @@
                             "tags.%": "1",
                             "tags.Name": "vpc-1-igw",
                             "vpc_id": "vpc-ca39caad"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.aws"
-                },
-                "aws_network_interface.web-server-ni": {
-                    "type": "aws_network_interface",
-                    "depends_on": [
-                        "aws_subnet.vpc-1-public-subnet"
-                    ],
-                    "primary": {
-                        "id": "eni-a453ea98",
-                        "attributes": {
-                            "attachment.#": "0",
-                            "description": "",
-                            "id": "eni-a453ea98",
-                            "private_dns_name": "",
-                            "private_ip": "10.0.1.10",
-                            "private_ips.#": "1",
-                            "private_ips.625443963": "10.0.1.10",
-                            "security_groups.#": "1",
-                            "security_groups.1523452012": "sg-4fde1e36",
-                            "source_dest_check": "true",
-                            "subnet_id": "subnet-3d69fe74",
-                            "tags.%": "0"
                         },
                         "meta": {},
                         "tainted": false
@@ -161,6 +132,42 @@
                             "subnet_id": "subnet-3d69fe74"
                         },
                         "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_security_group.web-sg": {
+                    "type": "aws_security_group",
+                    "depends_on": [
+                        "aws_vpc.vpc-1"
+                    ],
+                    "primary": {
+                        "id": "sg-be9152c7",
+                        "attributes": {
+                            "description": "Managed by Terraform",
+                            "egress.#": "0",
+                            "id": "sg-be9152c7",
+                            "ingress.#": "1",
+                            "ingress.2541437006.cidr_blocks.#": "1",
+                            "ingress.2541437006.cidr_blocks.0": "0.0.0.0/0",
+                            "ingress.2541437006.description": "",
+                            "ingress.2541437006.from_port": "22",
+                            "ingress.2541437006.ipv6_cidr_blocks.#": "0",
+                            "ingress.2541437006.protocol": "tcp",
+                            "ingress.2541437006.security_groups.#": "0",
+                            "ingress.2541437006.self": "false",
+                            "ingress.2541437006.to_port": "22",
+                            "name": "web-sg",
+                            "owner_id": "657349535912",
+                            "revoke_rules_on_delete": "false",
+                            "tags.%": "1",
+                            "tags.Name": "web-sg",
+                            "vpc_id": "vpc-ca39caad"
+                        },
+                        "meta": {
+                            "schema_version": "1"
+                        },
                         "tainted": false
                     },
                     "deposed": [],

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.11.1",
-    "serial": 7,
+    "serial": 10,
     "lineage": "9bc7f940-e849-43f4-a648-6c4237774fb9",
     "modules": [
         {
@@ -10,6 +10,62 @@
             ],
             "outputs": {},
             "resources": {
+                "aws_instance.web-server": {
+                    "type": "aws_instance",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "i-05dc749e699baec56",
+                        "attributes": {
+                            "ami": "ami-da9e2cbc",
+                            "associate_public_ip_address": "true",
+                            "availability_zone": "ap-northeast-1a",
+                            "disable_api_termination": "false",
+                            "ebs_block_device.#": "0",
+                            "ebs_optimized": "false",
+                            "ephemeral_block_device.#": "0",
+                            "iam_instance_profile": "",
+                            "id": "i-05dc749e699baec56",
+                            "instance_state": "running",
+                            "instance_type": "t2.micro",
+                            "ipv6_addresses.#": "0",
+                            "key_name": "",
+                            "monitoring": "false",
+                            "network_interface.#": "0",
+                            "network_interface_id": "eni-d666dfea",
+                            "placement_group": "",
+                            "primary_network_interface_id": "eni-d666dfea",
+                            "private_dns": "ip-172-31-25-127.ap-northeast-1.compute.internal",
+                            "private_ip": "172.31.25.127",
+                            "public_dns": "ec2-54-178-184-44.ap-northeast-1.compute.amazonaws.com",
+                            "public_ip": "54.178.184.44",
+                            "root_block_device.#": "1",
+                            "root_block_device.0.delete_on_termination": "true",
+                            "root_block_device.0.iops": "100",
+                            "root_block_device.0.volume_size": "8",
+                            "root_block_device.0.volume_type": "gp2",
+                            "security_groups.#": "1",
+                            "security_groups.3814588639": "default",
+                            "source_dest_check": "true",
+                            "subnet_id": "subnet-d2188d9b",
+                            "tags.%": "1",
+                            "tags.Name": "web-server",
+                            "tenancy": "default",
+                            "volume_tags.%": "0",
+                            "vpc_security_group_ids.#": "0"
+                        },
+                        "meta": {
+                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
+                                "create": 600000000000,
+                                "delete": 600000000000,
+                                "update": 600000000000
+                            },
+                            "schema_version": "1"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
                 "aws_internet_gateway.vpc-1-igw": {
                     "type": "aws_internet_gateway",
                     "depends_on": [

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,5 +1,6 @@
 resource "aws_vpc" "vpc-1" {
   cidr_block = "10.0.0.0/16"
+
   tags {
     Name = "vpc-1"
   }
@@ -9,6 +10,7 @@ resource "aws_subnet" "vpc-1-public-subnet" {
   vpc_id            = "${aws_vpc.vpc-1.id}"
   cidr_block        = "10.0.1.0/24"
   availability_zone = "ap-northeast-1a"
+
   tags {
     Name = "vpc-1-public-subnet"
   }
@@ -16,6 +18,7 @@ resource "aws_subnet" "vpc-1-public-subnet" {
 
 resource "aws_internet_gateway" "vpc-1-igw" {
   vpc_id = "${aws_vpc.vpc-1.id}"
+
   tags {
     Name = "vpc-1-igw"
   }
@@ -23,10 +26,12 @@ resource "aws_internet_gateway" "vpc-1-igw" {
 
 resource "aws_route_table" "vpc-1-public-rt" {
   vpc_id = "${aws_vpc.vpc-1.id}"
+
   route {
     cidr_block = "0.0.0.0/0"
     gateway_id = "${aws_internet_gateway.vpc-1-igw.id}"
   }
+
   tags {
     Name = "vpc-1-public-rt"
   }

--- a/vpc.tf
+++ b/vpc.tf
@@ -36,3 +36,8 @@ resource "aws_route_table_association" "vpc-1-rta-1" {
   subnet_id      = "${aws_subnet.vpc-1-public-subnet.id}"
   route_table_id = "${aws_route_table.vpc-1-public-rt.id}"
 }
+
+resource "aws_network_interface" "web-server-ni" {
+  subnet_id = "${aws_subnet.vpc-1-public-subnet.id}"
+  private_ips = ["10.0.1.10"]
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -37,7 +37,18 @@ resource "aws_route_table_association" "vpc-1-rta-1" {
   route_table_id = "${aws_route_table.vpc-1-public-rt.id}"
 }
 
-resource "aws_network_interface" "web-server-ni" {
-  subnet_id = "${aws_subnet.vpc-1-public-subnet.id}"
-  private_ips = ["10.0.1.10"]
+resource "aws_security_group" "web-sg" {
+  name   = "web-sg"
+  vpc_id = "${aws_vpc.vpc-1.id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "web-sg"
+  }
 }


### PR DESCRIPTION
- EC2インスタンス作成
- ~ネットワークインターフェースの作成とEC2インスタンスへの追加~
    - ~下記エラーが出たので自動割当パブリックIPは無効に~
    ```
    $ terraform plan
    Error: aws_instance.web-server: "network_interface": conflicts with associate_public_ip_address (true)
    ```
    - => `network_interface`を作成・追加する必要はなかったので削除
- セキュリティグループの追加

### refs
- [Terraformでawsのec2インスタンスを立ち上げる](https://qiita.com/bunty/items/5ceed66d334db0ff99e8)
- [[AWS][Terraform]EC2とVPCを自動化してみたら素晴らしかった
](https://blog.adachin.me/wordpress/archives/4693)
- https://github.com/terraform-aws-modules/terraform-aws-ec2-instance